### PR TITLE
Guard against double close of stream

### DIFF
--- a/includes/WindowsAzureFileBackend.php
+++ b/includes/WindowsAzureFileBackend.php
@@ -199,7 +199,9 @@ class WindowsAzureFileBackend extends FileBackendStore {
 				$status->fatal( 'backend-fail-store', $params['src'], $params['dst'] );
 			} else {
 				$this->proxy->createBlockBlob( $dstCont, $dstRel, $fp, $options );
-				fclose( $fp );
+				if ( is_resource($fp) ) { // guard against double close
+					fclose( $fp );
+				}
 			}
 		} catch ( ServiceException $e ) {
 			switch ( $e->getCode() ) {


### PR DESCRIPTION
The function createBlockBlob closes the upload stream itself so when reaching fclose ( $fp ) the stream is already closed and an error is thrown. I've added a condition to check if the stream has already been closed and if so skip the fclose command.